### PR TITLE
feat: Adiciona extração de áudio opcional ao comando sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ logs/
 # OS
 .DS_Store
 Thumbs.db 
+clonechat_user.session-journal
+
+# Project file
+canais.txt

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ data/clonechat.db
 
 # Downloads
 data/downloads/
+data/project_workspace/
 
 # Telegram session files
 *.session

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Ferramenta avançada para clonar chats do Telegram com arquitetura moderna e rec
 
 - **Clonagem Automática**: Criação automática de canais de destino
 - **Detecção Inteligente**: Estratégia automática (forward ou download-upload)
-- **Extração de Áudio**: Extração automática de áudio de vídeos via FFmpeg
-- **Força Download**: Opção para forçar estratégia download-upload e extrair áudio
+- **Extração de Áudio Opcional**: Extraia áudio de vídeos com a flag `--extract-audio` ao usar a estratégia `download-upload`.
+- **Forçar Estratégia**: Opção `--force-download` para forçar a estratégia `download-upload`.
 - **Salvamento de Links**: Arquivo `links_canais.txt` com links dos canais clonados
 - **Processamento de Mídia**: Suporte completo a todos os tipos de mensagem
 - **Logging Avançado**: Sistema de logs estruturado com saída para console e arquivo
@@ -246,13 +246,20 @@ poetry run python main.py sync --origin <ID_DO_CANAL>
 - **Não extrai áudio** se usar estratégia `forward`
 - **Não sai** do canal de origem por padrão
 
-### Clonagem com Extração de Áudio Forçada
+### Clonagem com Extração de Áudio (Requer Estratégia Download-Upload)
+```bash
+poetry run python main.py sync --origin <ID_DO_CANAL> --extract-audio
+```
+- **Extrai áudio** de vídeos se a estratégia `download-upload` for usada.
+- Arquivos MP3 são salvos na pasta do canal
+- Se o canal não permitir encaminhamento, a estratégia `download-upload` será usada automaticamente. Se permitir, use `--force-download` para forçar a estratégia e permitir a extração.
+
+### Clonagem Forçando Estratégia Download-Upload
 ```bash
 poetry run python main.py sync --origin <ID_DO_CANAL> --force-download
 ```
-- **Sempre usa** estratégia `download_upload`
-- **Sempre extrai áudio** de vídeos
-- Arquivos MP3 são salvos na pasta do canal
+- **Sempre usa** a estratégia `download-upload`, mesmo que o encaminhamento seja permitido.
+- **Não extrai áudio** por padrão. Use `--extract-audio` para isso.
 
 ### Clonagem para Canal Existente
 ```bash
@@ -286,8 +293,8 @@ poetry run python main.py sync --origin <ID_DO_CANAL> --publish-to <ID_GRUPO> --
 
 ### Combinações de Opções
 ```bash
-# Clonagem completa: extrair áudio, usar canal existente, sair do origem e publicar links
-poetry run python main.py sync --origin <ID_DO_CANAL> --force-download --dest <ID_DESTINO> --leave-origin --publish-to <ID_GRUPO>
+# Clonagem completa: forçar download, extrair áudio, usar canal existente, sair do origem e publicar links
+poetry run python main.py sync --origin <ID_DO_CANAL> --force-download --extract-audio --dest <ID_DESTINO> --leave-origin --publish-to <ID_GRUPO>
 
 # Clonagem simples para canal existente e publicar links
 poetry run python main.py sync --origin <ID_DO_CANAL> --dest <ID_DESTINO> --publish-to <ID_GRUPO>
@@ -300,7 +307,7 @@ poetry run python main.py sync --batch --source arquivo_com_ids.txt
 
 ### Clonagem em Lote com Extração de Áudio
 ```bash
-poetry run python main.py sync --batch --source arquivo_com_ids.txt --force-download
+poetry run python main.py sync --batch --source arquivo_com_ids.txt --extract-audio
 ```
 
 ### Modo Restart (Força Nova Clonagem)
@@ -483,8 +490,8 @@ Crie um arquivo de texto com IDs de chat, um por linha:
 - Animações, Video Notes, Polls
 
 ### Recursos Avançados
-- **Extração de Áudio**: Vídeos são processados para extrair áudio em MP3
-- **Força Download**: Opção `--force-download` para sempre extrair áudio
+- **Extração de Áudio**: Com a flag `--extract-audio`, vídeos são processados para extrair áudio em MP3 quando a estratégia `download-upload` é usada.
+- **Força Download**: Opção `--force-download` para sempre usar a estratégia `download-upload`.
 - **Canal de Destino Existente**: Opção `--dest` para usar canal existente
 - **Controle de Saída**: Opção `--leave-origin` para sair do canal de origem
 - **Salvamento de Links**: Links dos canais clonados salvos em `links_canais.txt`
@@ -638,7 +645,7 @@ Este projeto está sob a licença MIT. Veja o arquivo LICENSE para detalhes.
 - O arquivo `.env**não** deve ser versionado
 - Use o modo `--restart` com cuidado, pois apaga dados anteriores
 - O sistema cria automaticamente canais de destino (a menos que `--dest` seja especificado)
-- Use `--force-download` para garantir extração de áudio de todos os vídeos
+- Use a combinação `--force-download` e `--extract-audio` para garantir a extração de áudio de todos os vídeos.
 - Os arquivos MP3 extraídos são preservados na pasta do canal
 - Por padrão, o sistema **não sai** do canal de origem (use `--leave-origin` se necessário)
 - Ao usar `--dest`, certifique-se de ter permissões de escrita no canal de destino 
@@ -650,8 +657,8 @@ Este projeto está sob a licença MIT. Veja o arquivo LICENSE para detalhes.
 # 1. Verificar acesso ao canal
 poetry run python main.py test-resolve --id -1002859374479
 
-# 2. Clonar com extração de áudio e publicar links
-poetry run python main.py sync --origin -1002859374479 --force-download --publish-to -1001234567890
+# 2. Clonar com extração de áudio (forçando a estratégia de download) e publicar links
+poetry run python main.py sync --origin -1002859374479 --force-download --extract-audio --publish-to -1001234567890
 
 # 3. Verificar links salvos
 cat links_canais.txt

--- a/clonechat/cli.py
+++ b/clonechat/cli.py
@@ -120,7 +120,8 @@ async def run_sync_async(
     leave_origin: bool = False,
     dest: Optional[str] = None,
     publish_to: Optional[str] = None,
-    topic_id: Optional[int] = None
+    topic_id: Optional[int] = None,
+    extract_audio: bool = False
 ) -> None:
     """
     Async wrapper for the sync operation.
@@ -135,6 +136,7 @@ async def run_sync_async(
         dest: Destination channel ID, username or link (if None, creates a new channel).
         publish_to: ID, username or link of the group/channel to publish the links of cloned channels.
         topic_id: ID of the topic (for groups with topic enabled).
+        extract_audio: Whether to extract audio from videos when using download-upload strategy.
     """
     try:
         log_operation_start(logger, "run_sync_async", origin=origin, batch=batch, restart=restart)
@@ -169,7 +171,7 @@ async def run_sync_async(
         if publish_to:
             publish_chat_id = await resolve_chat_id(client, publish_to)
         
-        engine = ClonerEngine(config, client, force_download=force_download, leave_origin=leave_origin, dest_chat_id=dest_chat_id, publish_chat_id=publish_chat_id, topic_id=topic_id)
+        engine = ClonerEngine(config, client, force_download=force_download, leave_origin=leave_origin, dest_chat_id=dest_chat_id, publish_chat_id=publish_chat_id, topic_id=topic_id, extract_audio=extract_audio)
         logger.info("🚀 Motor de clonagem inicializado")
         
         if batch:
@@ -247,6 +249,11 @@ def sync(
         "-f",
         help="Forçar estratégia download_upload para extrair áudio de vídeos"
     ),
+    extract_audio: bool = typer.Option(
+        False,
+        "--extract-audio",
+        help="Extrair áudio de vídeos na estratégia download-upload (default: False)"
+    ),
     leave_origin: bool = typer.Option(
         False,
         "--leave-origin",
@@ -283,8 +290,8 @@ def sync(
     - Forward: Encaminhamento direto (mais rápido, sem extração de áudio)
     - Download-Upload: Download, processamento e upload (extrai áudio de vídeos)
     
-    Use --force-download para sempre usar a estratégia download_upload,
-    garantindo que o áudio seja extraído de todos os vídeos.
+    Use --force-download para sempre usar a estratégia download_upload.
+    Use --extract-audio para extrair o áudio dos vídeos ao usar a estratégia de download-upload.
     
     Use --dest para especificar um canal de destino existente em vez de criar um novo.
     Use --leave-origin para sair do canal de origem após a clonagem.
@@ -293,7 +300,7 @@ def sync(
     
     Modos de uso:
     - Individual: python main.py sync --origin 123456789
-    - Com extração de áudio: python main.py sync --origin 123456789 --force-download
+    - Com extração de áudio: python main.py sync --origin 123456789 --force-download --extract-audio
     - Para canal existente: python main.py sync --origin 123456789 --dest 987654321
     - Sair do canal origem: python main.py sync --origin 123456789 --leave-origin
     - Publicar links: python main.py sync --origin 123456789 --publish-to -1001234567890
@@ -316,7 +323,7 @@ def sync(
                 raise typer.BadParameter("--source só deve ser usado com --batch")
         
         # Executar operação assíncrona
-        asyncio.run(run_sync_async(origin, batch, source, restart, force_download, leave_origin, dest, publish_to, topic_id))
+        asyncio.run(run_sync_async(origin, batch, source, restart, force_download, leave_origin, dest, publish_to, topic_id, extract_audio))
         
         log_operation_success(logger, "sync_command", origin=origin, batch=batch, restart=restart)
         

--- a/clonechat/engine.py
+++ b/clonechat/engine.py
@@ -169,7 +169,7 @@ class ClonerEngine:
     Main cloning engine that handles automatic strategy detection and chat synchronization.
     """
     
-    def __init__(self, config: Config, client: Client, force_download: bool = False, leave_origin: bool = False, dest_chat_id: Optional[int] = None, publish_chat_id: Optional[int] = None, topic_id: Optional[int] = None):
+    def __init__(self, config: Config, client: Client, force_download: bool = False, leave_origin: bool = False, dest_chat_id: Optional[int] = None, publish_chat_id: Optional[int] = None, topic_id: Optional[int] = None, extract_audio: bool = False):
         """
         Initialize the ClonerEngine.
         
@@ -181,6 +181,7 @@ class ClonerEngine:
             dest_chat_id: Destination channel ID (if None, creates a new channel).
             publish_chat_id: Chat ID where to publish cloned channel links.
             topic_id: Topic ID for publishing in groups with topics.
+            extract_audio: If True, extract audio from videos.
         """
         self.config = config
         self.client = client
@@ -189,6 +190,7 @@ class ClonerEngine:
         self.dest_chat_id = dest_chat_id
         self.publish_chat_id = publish_chat_id
         self.topic_id = topic_id
+        self.extract_audio = extract_audio
         self.logger = get_logger(__name__)
         
         # Message ID mapping for pinned messages functionality
@@ -596,7 +598,8 @@ class ClonerEngine:
                 message=message,
                 destination_chat=dest_chat_id,
                 download_path=download_path,
-                delay_seconds=self.config.cloner_delay_seconds
+                delay_seconds=self.config.cloner_delay_seconds,
+                extract_audio=self.extract_audio
             )
             
             return sent_message_id

--- a/clonechat/processor.py
+++ b/clonechat/processor.py
@@ -759,6 +759,7 @@ async def download_process_upload(
     destination_chat: int,
     download_path: Path,
     delay_seconds: int,
+    extract_audio: bool = False,
 ) -> int:
     """
     Processes a message, handling both text and media types.
@@ -771,6 +772,7 @@ async def download_process_upload(
         destination_chat: The destination chat ID.
         download_path: The base directory for downloads for this task.
         delay_seconds: Delay after processing the message.
+        extract_audio: If True, extract audio from videos.
         
     Returns:
         The ID of the sent message.
@@ -801,7 +803,7 @@ async def download_process_upload(
             if downloaded_path:
                 # Extração de áudio é um efeito colateral, não afeta o upload
                 audio_path = None
-                if message.video:
+                if message.video and extract_audio:
                     await _extract_audio(message, downloaded_path)
                     # Get the audio file path that was created
                     audio_path = downloaded_path.with_suffix(".mp3")


### PR DESCRIPTION
Este pull request introduz a capacidade de controlar a extração de áudio durante a clonagem de vídeos, tornando-a uma funcionalidade opcional em vez de um comportamento padrão da estratégia `download-upload`.

Anteriormente, a extração de áudio estava diretamente acoplada à estratégia de `download-upload` (e, por consequência, à flag `--force-download`), o que nem sempre é desejado. Esta alteração desacopla essas duas funcionalidades, oferecendo maior flexibilidade e controle ao usuário.

### O que foi alterado?

-   **Nova Flag no CLI**: Adicionada a flag `--extract-audio` ao comando `sync`. Por padrão, seu valor é `False`.
-   **Lógica Condicional**: A extração de áudio agora só é executada dentro do `processor` se a flag `--extract-audio` for explicitamente fornecida e a estratégia `download-upload` estiver em uso.
-   **Desacoplamento de `--force-download`**: A flag `--force-download` agora serve apenas para forçar a estratégia de download e upload, sem implicar na extração de áudio.
-   **Atualização da Documentação**: O arquivo `README.md` foi completamente revisado para refletir a nova flag, ajustar as descrições das funcionalidades e atualizar os exemplos de uso.

### Como Testar

1.  Clone um canal que contenha vídeos e que permita encaminhamento de mensagens:
    ```bash
    # Sem a flag, o áudio NÃO deve ser extraído (usará 'forward')
    poetry run python main.py sync --origin <ID_DO_CANAL>
    ```

2.  Force a estratégia de download sem extrair o áudio:
    ```bash
    # Usando --force-download, o áudio NÃO deve ser extraído
    poetry run python main.py sync --origin <ID_DO_CANAL> --force-download
    ```

3.  Force a estratégia de download e extraia o áudio:
    ```bash
    # Usando --force-download e --extract-audio, o áudio DEVE ser extraído
    poetry run python main.py sync --origin <ID_DO_CANAL> --force-download --extract-audio
    ```

4.  Verifique se os arquivos de áudio (`.mp3`) são criados apenas no terceiro caso, dentro da pasta `data/downloads/`.